### PR TITLE
avoid null value coercion when annotated with @DefaultNull

### DIFF
--- a/src/main/java/org/skife/config/ConfigurationObjectFactory.java
+++ b/src/main/java/org/skife/config/ConfigurationObjectFactory.java
@@ -253,7 +253,9 @@ public class ConfigurationObjectFactory {
             }
         }
 
-        final Object finalValue = bully.coerce(method.getGenericReturnType(), value, method.getAnnotation(Separator.class));
+        final Object finalValue = value == null && hasDefaultNull
+                ? value
+                : bully.coerce(method.getGenericReturnType(), value, method.getAnnotation(Separator.class));
         return new ConfigMagicFixedValue(method, assignedFrom, finalValue);
     }
 


### PR DESCRIPTION
That coercion lead to unexpected behavior if property was of `org.joda.DateTime` type: you expect it to be `null` if not set, but it actually was calling `new DateTime(null)` (which is equivalent to `DateTime.now()`).